### PR TITLE
文字列リテラルをdouble_quotesに統一する

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,16 @@ AllCops:
     - "bin/**/*"
     - "tmp/**/*"
     - "node_modules/**/*"
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: double_quotes
+  Include:
+    - app/**/*
+    - config/**/*
+    - lib/**/*
+    - test/**/*
+    - spec/**/*
+    - Gemfile
 
 # 1つのテスト(it)の中に記述できる検証(expect)の数をチェック
 RSpec/MultipleExpectations:
@@ -29,4 +39,8 @@ RSpec/NestedGroups:
 
 # letやsubjectをブロックの先頭に書くことを強制するルールを無効化
 RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
+# 日本語コンテキストを許容する
+RSpec/ContextWording:
   Enabled: false

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Company, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe User, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,13 +1,13 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-require 'spec_helper'
-ENV['RAILS_ENV'] ||= 'test'
-require_relative '../config/environment'
+require "spec_helper"
+ENV["RAILS_ENV"] ||= "test"
+require_relative "../config/environment"
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 # Uncomment the line below in case you have `--require rails_helper` in the `.rspec` file
 # that will avoid rails generators crashing because migrations haven't been run yet
 # return unless Rails.env.test?
-require 'rspec/rails'
+require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -37,7 +37,7 @@ end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [
-    Rails.root.join('spec/fixtures')
+    Rails.root.join("spec/fixtures")
   ]
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Homes", type: :request do
   describe "GET /top" do

--- a/spec/requests/users/invitations_spec.rb
+++ b/spec/requests/users/invitations_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Users::Invitations", type: :request do
   describe "GET /index" do


### PR DESCRIPTION
## 実施タスク
文字列リテラルをdouble_quotesに統一する #29 

## 実施内容
- Style/StringLiteralsのEnforcedStyleをdouble_quotesに設定
- omakaseのInclude設定ではspec/が対象外だったため、spec/**/*を明示的に追加 

## レビューして欲しいこと
- 以下のコマンドを実行しても違反が検出されないこと
  - bundle exec rubocop
  - bundle exec rubocop -a  - 