### PR TITLE
Userモデルに関するバリデーションの修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,21 +8,12 @@ class User < ApplicationRecord
 
   enum role: { general: 0, admin: 1, retired: 2 }
 
-  VALID_NAME_REGEX = /\A[^\p{blank}]+ [^\p{blank}]+\z/
-  VALID_NAME_KANA_REGEX = /\A[ァ-ヶー]+(?: [ァ-ヶー]+)*\z/
-
   validates :email, uniqueness: { case_sensitive: false }, allowed_domain: true
 
   validates :name,
     length: { maximum: 20 }, name_format: true, allow_blank: true
   validates :name_kana,
-    length: { maximum: 20 },
-    format: { with: VALID_NAME_REGEX, message: "は氏名の間に半角スペースを入れてください" },
-    allow_blank: true
-  validates :name_kana,
-    format: { with: VALID_NAME_KANA_REGEX, message: "は全角カタカナで入力してください" },
-    allow_blank: true
-
+    length: { maximum: 20 }, name_kana_format: true, allow_blank: true
   validates :phone, phone: { possible: true, countries: :jp }, phone_format: true, allow_blank: true
 
   def active_for_authentication?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,9 +14,7 @@ class User < ApplicationRecord
   validates :email, uniqueness: { case_sensitive: false }, allowed_domain: true
 
   validates :name,
-    length: { maximum: 20 },
-    format: { with: VALID_NAME_REGEX, message: "は氏名の間に半角スペースを入れてください" },
-    allow_blank: true
+    length: { maximum: 20 }, name_format: true, allow_blank: true
   validates :name_kana,
     length: { maximum: 20 },
     format: { with: VALID_NAME_REGEX, message: "は氏名の間に半角スペースを入れてください" },

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,8 +8,8 @@ class User < ApplicationRecord
 
   enum role: { general: 0, admin: 1, retired: 2 }
 
-  validates :email, uniqueness: { case_sensitive: false }, allowed_domain: true
-
+  validates :email,
+    uniqueness: { case_sensitive: false }, allowed_domain: true
   validates :name,
     length: { maximum: 20 }, name_format: true, allow_blank: true
   validates :name_kana,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,8 @@ class User < ApplicationRecord
     length: { maximum: 20 }, name_format: true, allow_blank: true
   validates :name_kana,
     length: { maximum: 20 }, name_kana_format: true, allow_blank: true
-  validates :phone, phone: { possible: true, countries: :jp }, phone_format: true, allow_blank: true
+  validates :phone,
+    phone_format: true, allow_blank: true
 
   def active_for_authentication?
     super && !retired?

--- a/app/validators/concerns/name_format_patterns.rb
+++ b/app/validators/concerns/name_format_patterns.rb
@@ -1,0 +1,4 @@
+module NameFormatPatterns
+  VALID_NAME_REGEX = /\A[^\p{blank}]+ [^\p{blank}]+\z/
+  VALID_NAME_KANA_REGEX = /\A[ァ-ヶー]+(?: [ァ-ヶー]+)*\z/
+end

--- a/app/validators/name_format_validator.rb
+++ b/app/validators/name_format_validator.rb
@@ -1,5 +1,5 @@
 class NameFormatValidator < ActiveModel::EachValidator
-  VALID_NAME_REGEX = /\A[^\p{blank}]+ [^\p{blank}]+\z/
+  include NameFormatPatterns
 
   def validate_each(record, attribute, value)
     return if value.blank?

--- a/app/validators/name_format_validator.rb
+++ b/app/validators/name_format_validator.rb
@@ -1,0 +1,11 @@
+class NameFormatValidator < ActiveModel::EachValidator
+  VALID_NAME_REGEX = /\A[^\p{blank}]+ [^\p{blank}]+\z/
+
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    unless value.match?(VALID_NAME_REGEX)
+      record.errors.add(attribute, "は氏名の間に半角スペースを入れてください")
+    end
+  end
+end

--- a/app/validators/name_kana_format_validator.rb
+++ b/app/validators/name_kana_format_validator.rb
@@ -1,6 +1,5 @@
 class NameKanaFormatValidator < ActiveModel::EachValidator
-  VALID_NAME_REGEX = /\A[^\p{blank}]+ [^\p{blank}]+\z/
-  VALID_NAME_KANA_REGEX = /\A[ァ-ヶー]+(?: [ァ-ヶー]+)*\z/
+  include NameFormatPatterns
 
   def validate_each(record, attribute, value)
     return if value.blank?

--- a/app/validators/name_kana_format_validator.rb
+++ b/app/validators/name_kana_format_validator.rb
@@ -1,0 +1,14 @@
+class NameKanaFormatValidator < ActiveModel::EachValidator
+  VALID_NAME_REGEX = /\A[^\p{blank}]+ [^\p{blank}]+\z/
+  VALID_NAME_KANA_REGEX = /\A[ァ-ヶー]+(?: [ァ-ヶー]+)*\z/
+
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    if !value.match?(VALID_NAME_REGEX)
+      record.errors.add(attribute, :invalid, message: "は氏名の間に半角スペースを入れてください")
+    elsif !value.match?(VALID_NAME_KANA_REGEX)
+      record.errors.add(attribute, :invalid, message: "は全角カタカナで入力してください")
+    end
+  end
+end


### PR DESCRIPTION
## 実施タスク
Userモデルに関するバリデーションの修正 #32 

## 実施内容
- NameFormatValidator と NameKanaFormatValidator を新規作成し、名前・名前カナのバリデーションを独立したバリデーターに切り出した（`return if value.blank?` で堅牢性を向上）
- NameFormatPatterns を concerns に切り出し、両バリデーターで共通利用できるようにした
- name / name_kana 属性のバリデーションに `allow_blank: true` を付与した（可読性の向上）
- email 属性のバリデーション記述を見やすい形に整形した
- phone 属性のバリデーションに PhoneFormatValidator を適用した
