### PR TITLE
Userモデルのアカウント無効化機能に関するRequest Spec作成

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,6 +71,7 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include FactoryBot::Syntax::Methods
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe "Users::Registrations", type: :request do
+  describe "PATCH /users/deactivate" do
+    context "ログイン済みユーザーの場合" do
+      context "retiredユーザーの場合" do
+        let(:user) { create(:user) }
+
+        it "roleがretiredに更新されること" do
+          sign_in user
+          patch deactivate_user_registration_path
+          expect(user.reload.role).to eq "retired"
+        end
+
+        it "ログアウトされること" do
+          sign_in user
+          patch deactivate_user_registration_path
+          expect(controller.current_user).to be_nil
+        end
+
+        it "root_pathにリダイレクトされること" do
+          sign_in user
+          patch deactivate_user_registration_path
+          expect(response).to redirect_to root_path
+        end
+
+        it "アカウント無効化に関するフラッシュメッセージが表示されること" do
+          sign_in user
+          patch deactivate_user_registration_path
+          expect(flash[:notice]).to eq "アカウントを無効化しました。"
+        end
+      end
+    end
+
+    context "ログインしていないユーザーの場合" do
+      context "retiredユーザーの場合" do
+        let(:user) { create(:user, :retired) }
+
+        it "ログインできないこと" do
+          sign_in user
+          expect(user.active_for_authentication?).to be false
+        end
+
+        it "メッセージキーretired_accountを返すこと" do
+          expect(user.inactive_message).to eq :retired_account
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 実施タスク
Userモデルのアカウント無効化機能に関するRequest Spec作成 #37 

## 実施内容
- Deviseのヘルパーモジュール読み込み設定を追加
- Devise Userのアカウント無効化機能に関するRequest Spec作成

## レビューして欲しいこと
- Request Spec のテストがパスすること
- テストコードに過不足がないこと

## 関連Issue
close #37  