### PR TITLE
require_company!による会社登録済みチェックを全体適用（company_registered!の修正）

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,7 +24,7 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def company_registered!
+  def require_company!
     return unless user_signed_in?
     return if current_user.company.present?
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
   allow_browser versions: :modern
   before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :require_company!, unless: :devise_controller?
 
   protected
 

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -1,4 +1,5 @@
 class CompaniesController < ApplicationController
+  skip_before_action :require_company!, only: %i[ new create ]
   before_action :set_company, only: %i[ show edit update ]
 
   def show

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,6 @@
 class PagesController < ApplicationController
+  skip_before_action :require_company!, only: %i[ invitation_required ]
+
   def invitation_required
     redirect_to root_path if current_user&.company.present?
   end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -1,6 +1,6 @@
 class Users::InvitationsController < Devise::InvitationsController
+  before_action :require_company!, only: %i[ new create ]
   before_action :require_admin!, only: %i[ new create ]
-  before_action :company_registered!, only: %i[ new create ]
   before_action :reject_other_company_user!, only: %i[ create ]
 
   skip_before_action :authenticate_user!, only: %i[ edit update ]


### PR DESCRIPTION
## 実行タスク
require_company!による会社登録済みチェックを全体適用（company_registered!の修正） #41 

## 実施内容
- ApplicationControllerにrequire_company!を適用（devise controller以外）
- require_company!が不要なControllerではskipする

## レビューして欲しいこと
以下の動作を確認して欲しい
- ログイン前
  - ログイン画面が表示されること（app/controllers/application_controller.rb #L6）
- companyを持たないadminユーザーでログイン後
  - 自社情報を新規登録できること（app/controllers/companies_controller.rb #L2）
- companyを持たないgeneralユーザーでログイン後
  - 招待待ち画面が表示されること（app/controllers/pages_controller.rb #L2）
- companyを持つadminユーザーでログイン後
  - メンバー招待画面を表示し、招待メールを送信できること（app/controllers/pages_controller.rb #L2）

## 関連Issue
close #41 