### PR TITLE
company_registered!のアクセス制御をPunditで実装する

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.24.5)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     cgi (0.4.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,12 +1,13 @@
 class ApplicationController < ActionController::Base
   include Pundit::Authorization
+
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
   before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
-  before_action :require_company!, unless: :devise_controller?
+  after_action :verify_authorized, unless: :devise_controller?
 
   protected
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,18 +30,18 @@ class ApplicationController < ActionController::Base
   private
 
   def user_not_authorized
-    flash[:alert] = "権限がありません。"
-    redirect_back(fallback_location: root_path)
+    if user_signed_in? && current_user.company.nil?
+      redirect_to_company_registration
+    else
+      redirect_back fallback_location: root_path, alert: "権限がありません。"
+    end
   end
 
-  def require_company!
-    return unless user_signed_in?
-    return if current_user.company.present?
-
+  def redirect_to_company_registration
     if current_user.admin?
-      redirect_to new_company_path, alert: "自社情報を登録してください"
+      redirect_to new_company_path, alert: "自社情報を登録してください。"
     else
-      redirect_to invitation_required_path, alert: "管理者ユーザーから招待メールを受け取ってください"
+      redirect_to invitation_required_path, alert: "管理者ユーザーから招待メールを受け取ってください。"
     end
   end
 end

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -1,16 +1,18 @@
 class CompaniesController < ApplicationController
-  skip_before_action :require_company!, only: %i[ new create ]
   before_action :set_company, only: %i[ show edit update ]
 
   def show
+    authorize @company
   end
 
   def new
     @company = Company.new
+    authorize @company
   end
 
   def create
     @company = Company.new(company_params)
+    authorize @company
 
     if @company.save
       current_user.update!(company_id: @company.id)
@@ -21,9 +23,11 @@ class CompaniesController < ApplicationController
   end
 
   def edit
+    authorize @company
   end
 
   def update
+    authorize @company
     if @company.update(company_params)
       redirect_to company_url(@company), status: :see_other, notice: "自社情報を更新しました"
     else

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,5 +2,6 @@ class HomeController < ApplicationController
   skip_before_action :authenticate_user!
 
   def top
+    skip_authorization
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,7 +1,5 @@
 class PagesController < ApplicationController
-  skip_before_action :require_company!, only: %i[ invitation_required ]
-
   def invitation_required
-    redirect_to root_path if current_user&.company.present?
+    authorize :page
   end
 end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -1,4 +1,5 @@
 class Users::InvitationsController < Devise::InvitationsController
+  after_action :verify_authorized, only: %i[ new create ]
   before_action :require_admin!, only: %i[ new create ]
   before_action :reject_other_company_user!, only: %i[ create ]
 

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -1,5 +1,4 @@
 class Users::InvitationsController < Devise::InvitationsController
-  before_action :require_company!, only: %i[ new create ]
   before_action :require_admin!, only: %i[ new create ]
   before_action :reject_other_company_user!, only: %i[ create ]
 
@@ -9,7 +8,13 @@ class Users::InvitationsController < Devise::InvitationsController
 
   before_action :validate_email!, only: :create
 
+  def new
+    authorize User
+    super
+  end
+
   def create
+    authorize User
     existing_user = User.find_by(email: invite_params[:email])
 
     if existing_user

--- a/app/policies/company_policy.rb
+++ b/app/policies/company_policy.rb
@@ -25,6 +25,10 @@ class CompanyPolicy < ApplicationPolicy
     edit?
   end
 
+  def show_navigation_link?
+    user.general? && show?
+  end
+
   class Scope < ApplicationPolicy::Scope
     # NOTE: Be explicit about which records you allow access to!
     # def resolve

--- a/app/policies/company_policy.rb
+++ b/app/policies/company_policy.rb
@@ -1,0 +1,34 @@
+class CompanyPolicy < ApplicationPolicy
+  # NOTE: Up to Pundit v2.3.1, the inheritance was declared as
+  # `Scope < Scope` rather than `Scope < ApplicationPolicy::Scope`.
+  # In most cases the behavior will be identical, but if updating existing
+  # code, beware of possible changes to the ancestors:
+  # https://gist.github.com/Burgestrand/4b4bc22f31c8a95c425fc0e30d7ef1f5
+
+  def show?
+    user.company_id == record.id
+  end
+
+  def new?
+    user.admin? && user.company_id.nil?
+  end
+
+  def create?
+    new?
+  end
+
+  def edit?
+    user.admin? && user.company_id == record.id
+  end
+
+  def update?
+    edit?
+  end
+
+  class Scope < ApplicationPolicy::Scope
+    # NOTE: Be explicit about which records you allow access to!
+    # def resolve
+    #   scope.all
+    # end
+  end
+end

--- a/app/policies/company_policy.rb
+++ b/app/policies/company_policy.rb
@@ -29,6 +29,10 @@ class CompanyPolicy < ApplicationPolicy
     user.general? && show?
   end
 
+  def edit_navigation_link?
+    edit?
+  end
+
   class Scope < ApplicationPolicy::Scope
     # NOTE: Be explicit about which records you allow access to!
     # def resolve

--- a/app/policies/page_policy.rb
+++ b/app/policies/page_policy.rb
@@ -1,0 +1,18 @@
+class PagePolicy < ApplicationPolicy
+  # NOTE: Up to Pundit v2.3.1, the inheritance was declared as
+  # `Scope < Scope` rather than `Scope < ApplicationPolicy::Scope`.
+  # In most cases the behavior will be identical, but if updating existing
+  # code, beware of possible changes to the ancestors:
+  # https://gist.github.com/Burgestrand/4b4bc22f31c8a95c425fc0e30d7ef1f5
+
+  def invitation_required?
+    user.general? && user.company.nil?
+  end
+
+  class Scope < ApplicationPolicy::Scope
+    # NOTE: Be explicit about which records you allow access to!
+    # def resolve
+    #   scope.all
+    # end
+  end
+end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -13,10 +13,6 @@ class UserPolicy < ApplicationPolicy
     new?
   end
 
-  def invite_navigation_link?
-    new?
-  end
-
   class Scope < ApplicationPolicy::Scope
     # NOTE: Be explicit about which records you allow access to!
     # def resolve

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,0 +1,22 @@
+class UserPolicy < ApplicationPolicy
+  # NOTE: Up to Pundit v2.3.1, the inheritance was declared as
+  # `Scope < Scope` rather than `Scope < ApplicationPolicy::Scope`.
+  # In most cases the behavior will be identical, but if updating existing
+  # code, beware of possible changes to the ancestors:
+  # https://gist.github.com/Burgestrand/4b4bc22f31c8a95c425fc0e30d7ef1f5
+
+  def new?
+    user.company.present?
+  end
+
+  def create?
+    new?
+  end
+
+  class Scope < ApplicationPolicy::Scope
+    # NOTE: Be explicit about which records you allow access to!
+    # def resolve
+    #   scope.all
+    # end
+  end
+end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -13,6 +13,10 @@ class UserPolicy < ApplicationPolicy
     new?
   end
 
+  def invite_navigation_link?
+    new?
+  end
+
   class Scope < ApplicationPolicy::Scope
     # NOTE: Be explicit about which records you allow access to!
     # def resolve

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -12,7 +12,7 @@
           <% end %>
         </li>
 
-        <% if current_user.general? %>
+        <% if policy(current_user.company).show_navigation_link? %>
           <hr class="my-4 mx-5 border-gray-100">
           <li>
             <%= link_to company_path(current_user.company), class: "flex items-center gap-3 px-3 py-2.5 mx-3 rounded-lg text-sm font-medium transition-colors #{current_page?(company_path(current_user.company)) ? 'bg-blue-50 text-blue-600' : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'}" do %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -24,27 +24,31 @@
           </li>
         <% end %>
 
-        <% if current_user.admin? %>
+        <% if policy(current_user.company).edit_navigation_link? || policy(User).invite_navigation_link? %>
           <hr class="my-4 mx-5 border-gray-100">
           <p class="px-6 py-1 text-xs text-gray-400 font-semibold tracking-wider">管理者メニュー</p>
 
-          <li>
-            <%= link_to edit_company_url(current_user.company), class: "flex items-center gap-3 px-3 py-2.5 mx-3 rounded-lg text-sm font-medium transition-colors #{current_page?(edit_company_url(current_user.company)) ? 'bg-blue-50 text-blue-600' : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'}" do %>
-              <svg class="w-5 h-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
-              </svg>
-              <span><%= Company.model_name.human %></span>
-            <% end %>
-          </li>
+          <% if policy(current_user.company).edit_navigation_link? %>
+            <li>
+              <%= link_to edit_company_url(current_user.company), class: "flex items-center gap-3 px-3 py-2.5 mx-3 rounded-lg text-sm font-medium transition-colors #{current_page?(edit_company_url(current_user.company)) ? 'bg-blue-50 text-blue-600' : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'}" do %>
+                <svg class="w-5 h-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
+                </svg>
+                <span><%= Company.model_name.human %></span>
+              <% end %>
+            </li>
+          <% end %>
 
-          <li>
-            <%= link_to new_user_invitation_path, class: "flex items-center gap-3 px-3 py-2.5 mx-3 rounded-lg text-sm font-medium transition-colors #{current_page?(new_user_invitation_path) ? 'bg-blue-50 text-blue-600' : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'}" do %>
-              <svg class="w-5 h-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />
-              </svg>
-              <span>招待</span>
-            <% end %>
-          </li>
+          <% if policy(User).invite_navigation_link? %>
+            <li>
+              <%= link_to new_user_invitation_path, class: "flex items-center gap-3 px-3 py-2.5 mx-3 rounded-lg text-sm font-medium transition-colors #{current_page?(new_user_invitation_path) ? 'bg-blue-50 text-blue-600' : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'}" do %>
+                <svg class="w-5 h-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />
+                </svg>
+                <span>招待</span>
+              <% end %>
+            </li>
+          <% end %>
         <% end %>
 
       </ul>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -24,31 +24,27 @@
           </li>
         <% end %>
 
-        <% if policy(current_user.company).edit_navigation_link? || policy(User).invite_navigation_link? %>
+        <% if policy(current_user.company).edit_navigation_link? %>
           <hr class="my-4 mx-5 border-gray-100">
           <p class="px-6 py-1 text-xs text-gray-400 font-semibold tracking-wider">管理者メニュー</p>
 
-          <% if policy(current_user.company).edit_navigation_link? %>
-            <li>
-              <%= link_to edit_company_url(current_user.company), class: "flex items-center gap-3 px-3 py-2.5 mx-3 rounded-lg text-sm font-medium transition-colors #{current_page?(edit_company_url(current_user.company)) ? 'bg-blue-50 text-blue-600' : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'}" do %>
-                <svg class="w-5 h-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
-                </svg>
-                <span><%= Company.model_name.human %></span>
-              <% end %>
-            </li>
-          <% end %>
+          <li>
+            <%= link_to edit_company_url(current_user.company), class: "flex items-center gap-3 px-3 py-2.5 mx-3 rounded-lg text-sm font-medium transition-colors #{current_page?(edit_company_url(current_user.company)) ? 'bg-blue-50 text-blue-600' : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'}" do %>
+              <svg class="w-5 h-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
+              </svg>
+              <span><%= Company.model_name.human %></span>
+            <% end %>
+          </li>
 
-          <% if policy(User).invite_navigation_link? %>
-            <li>
-              <%= link_to new_user_invitation_path, class: "flex items-center gap-3 px-3 py-2.5 mx-3 rounded-lg text-sm font-medium transition-colors #{current_page?(new_user_invitation_path) ? 'bg-blue-50 text-blue-600' : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'}" do %>
-                <svg class="w-5 h-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />
-                </svg>
-                <span>招待</span>
-              <% end %>
-            </li>
-          <% end %>
+          <li>
+            <%= link_to new_user_invitation_path, class: "flex items-center gap-3 px-3 py-2.5 mx-3 rounded-lg text-sm font-medium transition-colors #{current_page?(new_user_invitation_path) ? 'bg-blue-50 text-blue-600' : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'}" do %>
+              <svg class="w-5 h-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />
+              </svg>
+              <span>招待</span>
+            <% end %>
+          </li>
         <% end %>
 
       </ul>


### PR DESCRIPTION
## 実施タスク
company_registered!のアクセス制御をPunditで実装する #47 

## 実施内容
`require_company!` メソッドによるアクセス制御を Pundit の Policy クラスに置き換えました。
これにより、二重リダイレクトを解消し、コントローラーをシンプルに保ちます。

- Punditの設定
  - `ApplicationController` に `verify_authorized` を適用（Devise 関連コントローラーは除外）
  - 権限エラーが発生した際の共通処理として user_not_authorized メソッドを追加
- 各コントローラーに呼び出された `require_company!` メソッドをPolicyに置き換える
  - `CompanyPolicy` を作成し、`CompaniesController` をリファクタリング
  - `PagePolicy` を作成し、`PagesController` をリファクタリング
  - `UserPolicy` を作成し、`Users::InvitationsController` の `require_company!` を `UserPolicy` に置き換える
  - `Users::InvitationsController` の `new`, `create` に `verify_authorized` を適用
  - アクセス制御が不要な `HomeController#top` に `skip_authorization` を記述
- ビューの修正
  - `app/views/layouts/_navbar.html.erb` における、「自社情報（詳細・編集）」および「ユーザー招待」リンクの表示条件を、Pundit の `policy` ヘルパーを使用する形へリファクタリング

## 動作確認
- `GET /companies/new`, `POST /companies` には、adminユーザー（Company 未登録）のみがアクセスできること
- 上記 URL に対し、adminユーザー（Company 登録済み）、およびgeneralユーザーがアクセスした場合、`user_not_authorized` が実行されること
- `GET /companies/:id` には、generalユーザー（Company 登録済み）のみがアクセスできること
- 上記 URL に対し、ユーザーが他社（自身が所属していない会社）の IDを指定してアクセスした場合、`user_not_authorized` が実行されること
- `GET /users/invitation/new`,  `POST /users/invitation`には、adminユーザー（Company 登録済み）のみがアクセスできること
- 上記 URL に対し、adminユーザー（Company 未登録）、およびgeneralユーザーがアクセスした場合、`user_not_authorized` が実行されること
- `HomeController#top` で `verify_authorized` のエラーが発生しないこと
- `_navbar.html.erb` の各リンクが Policy の条件通りに表示・非表示が切り替わること

## 関連Issue
close #47 
