### PR TITLE
CompaniesControllerに関するRequest Spec作成

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -16,7 +16,7 @@ class CompaniesController < ApplicationController
 
     if @company.save
       current_user.update!(company_id: @company.id)
-      redirect_to edit_company_url(@company), status: :see_other, notice: "自社情報を登録しました"
+      redirect_to edit_company_url(@company), status: :see_other, notice: "自社情報を登録しました。"
     else
       render :new, status: :unprocessable_entity
     end
@@ -29,7 +29,7 @@ class CompaniesController < ApplicationController
   def update
     authorize @company
     if @company.update(company_params)
-      redirect_to edit_company_url(@company), status: :see_other, notice: "自社情報を更新しました"
+      redirect_to edit_company_url(@company), status: :see_other, notice: "自社情報を更新しました。"
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -29,7 +29,7 @@ class CompaniesController < ApplicationController
   def update
     authorize @company
     if @company.update(company_params)
-      redirect_to company_url(@company), status: :see_other, notice: "自社情報を更新しました"
+      redirect_to edit_company_url(@company), status: :see_other, notice: "自社情報を更新しました"
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/policies/company_policy.rb
+++ b/app/policies/company_policy.rb
@@ -25,14 +25,6 @@ class CompanyPolicy < ApplicationPolicy
     edit?
   end
 
-  def show_navigation_link?
-    show?
-  end
-
-  def edit_navigation_link?
-    edit?
-  end
-
   class Scope < ApplicationPolicy::Scope
     # NOTE: Be explicit about which records you allow access to!
     # def resolve

--- a/app/policies/company_policy.rb
+++ b/app/policies/company_policy.rb
@@ -6,7 +6,7 @@ class CompanyPolicy < ApplicationPolicy
   # https://gist.github.com/Burgestrand/4b4bc22f31c8a95c425fc0e30d7ef1f5
 
   def show?
-    user.company_id == record.id
+    user.general? && user.company_id == record.id
   end
 
   def new?
@@ -26,7 +26,7 @@ class CompanyPolicy < ApplicationPolicy
   end
 
   def show_navigation_link?
-    user.general? && show?
+    show?
   end
 
   def edit_navigation_link?

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -12,7 +12,7 @@
           <% end %>
         </li>
 
-        <% if policy(current_user.company).show_navigation_link? %>
+        <% if policy(current_user.company).show? %>
           <hr class="my-4 mx-5 border-gray-100">
           <li>
             <%= link_to company_path(current_user.company), class: "flex items-center gap-3 px-3 py-2.5 mx-3 rounded-lg text-sm font-medium transition-colors #{current_page?(company_path(current_user.company)) ? 'bg-blue-50 text-blue-600' : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'}" do %>
@@ -24,7 +24,7 @@
           </li>
         <% end %>
 
-        <% if policy(current_user.company).edit_navigation_link? %>
+        <% if policy(current_user.company).edit? %>
           <hr class="my-4 mx-5 border-gray-100">
           <p class="px-6 py-1 text-xs text-gray-400 font-semibold tracking-wider">管理者メニュー</p>
 

--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -5,5 +5,9 @@ FactoryBot.define do
     address { "東京都千代田区千代田1-1" }
     phone { "0312345678" }
     fax { "0312345679" }
+
+    trait :invalid do
+      name { nil }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -22,6 +22,10 @@ FactoryBot.define do
       role { :admin }
     end
 
+    trait :general do
+      role { :general }
+    end
+
     trait :retired do
       role { :retired }
     end

--- a/spec/requests/companies_spec.rb
+++ b/spec/requests/companies_spec.rb
@@ -239,4 +239,88 @@ RSpec.describe "Companies", type: :request do
       end
     end
   end
+
+  describe "PATCH /companies/:id" do
+    context "ログイン済みの場合" do
+      context "company登録済みの場合" do
+        context "adminユーザーの場合" do
+          let(:user) { create(:user, :admin, :with_company) }
+
+          context "有効なパラメータを送信した場合" do
+            it "ステータスコード303を返すこと" do
+              sign_in user
+              patch company_path(user.company), params: { company: attributes_for(:company) }
+              expect(response).to have_http_status(:see_other)
+            end
+
+            it "自社情報の更新に成功すること" do
+              sign_in user
+              expect {
+                patch company_path(user.company), params: {
+                  company: attributes_for(:company, name: "新しい会社名")
+                }
+              }.to change { user.company.reload.name }.to("新しい会社名")
+            end
+
+            it "自社情報編集ページにリダイレクトすること" do
+              sign_in user
+              patch company_path(user.company), params: { company: attributes_for(:company) }
+              expect(response).to redirect_to(edit_company_path(user.company))
+            end
+          end
+
+          context "無効なパラメータを送信した場合" do
+            it "ステータスコード422を返すこと" do
+              sign_in user
+              patch company_path(user.company), params: { company: attributes_for(:company, :invalid) }
+              expect(response).to have_http_status(:unprocessable_entity)
+            end
+
+            it "自社情報の更新に失敗すること" do
+              sign_in user
+              expect {
+                patch company_path(user.company), params: {
+                  company: attributes_for(:company, :invalid)
+                }
+              }.not_to change { user.company.reload.name }
+            end
+          end
+        end
+
+        context "generalユーザーの場合" do
+          let(:user) { create(:user, :general, :with_company) }
+
+          it "トップページにリダイレクトすること" do
+            sign_in user
+            patch company_path(user.company), params: { company: attributes_for(:company) }
+            expect(response).to redirect_to(root_path)
+          end
+        end
+      end
+
+      context "company未登録の場合" do
+        let(:other_user) { create(:user, :admin, :with_company) }
+
+        context "adminユーザーの場合" do
+          let(:user) { create(:user, :admin, company: nil) }
+
+          it "自社情報登録ページにリダイレクトすること" do
+            sign_in user
+            patch company_path(other_user.company), params: { company: attributes_for(:company) }
+            expect(response).to redirect_to(new_company_path)
+          end
+        end
+
+        context "generalユーザーの場合" do
+          let(:user) { create(:user, :general, company: nil) }
+
+          it "招待待ちページにリダイレクトすること" do
+            sign_in user
+            patch company_path(other_user.company), params: { company: attributes_for(:company) }
+            expect(response).to redirect_to(invitation_required_path)
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/companies_spec.rb
+++ b/spec/requests/companies_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe "Companies", type: :request do
+  describe "GET /companies/:id" do
+    context "ログイン済みの場合" do
+      context "company登録済みの場合" do
+        context "adminユーザーの場合" do
+          let(:user) { create(:user, :admin, :with_company) }
+
+          it "トップページにリダイレクトすること" do
+            sign_in user
+            get company_path(user.company)
+            expect(response).to redirect_to(root_path)
+          end
+        end
+
+        context "generalユーザーの場合" do
+          let(:user) { create(:user, :general, :with_company) }
+
+          it "HTTPステータス200を返すこと" do
+            sign_in user
+            get company_path(user.company)
+            expect(response).to have_http_status(:ok)
+          end
+
+          it "自社情報が取得できること" do
+            sign_in user
+            get company_path(user.company)
+            expect(response.body).to include(user.company.name)
+          end
+        end
+      end
+
+      context "company未登録の場合" do
+        let(:other_user) { create(:user, :admin, :with_company) }
+
+        context "adminユーザーの場合" do
+          let(:user) { create(:user, :admin, company: nil) }
+
+          it "自社情報登録ページにリダイレクトすること" do
+            sign_in user
+            get company_path(other_user.company)
+            expect(response).to redirect_to(new_company_path)
+          end
+        end
+
+        context "generalユーザーの場合" do
+          let(:user) { create(:user, :general, company: nil) }
+
+          it "招待待ちページにリダイレクトすること" do
+            sign_in user
+            get company_path(other_user.company)
+            expect(response).to redirect_to(invitation_required_path)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/companies_spec.rb
+++ b/spec/requests/companies_spec.rb
@@ -189,4 +189,54 @@ RSpec.describe "Companies", type: :request do
       end
     end
   end
+
+  describe "GET /companies/:id/edit" do
+    context "ログイン済みの場合" do
+      context "company登録済みの場合" do
+        context "adminユーザーの場合" do
+          let(:user) { create(:user, :admin, :with_company) }
+
+          it "HTTPステータス200を返すこと" do
+            sign_in user
+            get edit_company_path(user.company)
+            expect(response).to have_http_status(:ok)
+          end
+        end
+
+        context "generalユーザーの場合" do
+          let(:user) { create(:user, :general, :with_company) }
+
+          it "トップページにリダイレクトすること" do
+            sign_in user
+            get edit_company_path(user.company)
+            expect(response).to redirect_to(root_path)
+          end
+        end
+      end
+
+      context "company未登録の場合" do
+        let(:other_user) { create(:user, :admin, :with_company) }
+
+        context "adminユーザーの場合" do
+          let(:user) { create(:user, :admin, company: nil) }
+
+          it "自社情報登録ページにリダイレクトすること" do
+            sign_in user
+            get edit_company_path(other_user.company)
+            expect(response).to redirect_to(new_company_path)
+          end
+        end
+
+        context "generalユーザーの場合" do
+          let(:user) { create(:user, :general, company: nil) }
+
+          it "招待待ちページにリダイレクトすること" do
+            sign_in user
+            get edit_company_path(other_user.company)
+            expect(response).to redirect_to(invitation_required_path)
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/companies_spec.rb
+++ b/spec/requests/companies_spec.rb
@@ -104,4 +104,89 @@ RSpec.describe "Companies", type: :request do
       end
     end
   end
+
+  describe "POST /companies" do
+    context "ログイン済みの場合" do
+      context "company登録済みの場合" do
+        context "adminユーザーの場合" do
+          let(:user) { create(:user, :admin, :with_company) }
+
+          it "トップページにリダイレクトすること" do
+            sign_in user
+            post companies_path, params: { company: attributes_for(:company) }
+            expect(response).to redirect_to(root_path)
+          end
+        end
+
+        context "generalユーザーの場合" do
+          let(:user) { create(:user, :general, :with_company) }
+
+          it "トップページにリダイレクトすること" do
+            sign_in user
+            post companies_path, params: { company: attributes_for(:company) }
+            expect(response).to redirect_to(root_path)
+          end
+        end
+      end
+
+      context "company未登録の場合" do
+        context "adminユーザーの場合" do
+          let(:user) { create(:user, :admin, company: nil) }
+
+          context "有効なパラメータを送信した場合" do
+            it "ステータスコード303を返すこと" do
+              sign_in user
+              post companies_path, params: { company: attributes_for(:company) }
+              expect(response).to have_http_status(:see_other)
+            end
+
+            it "作成した自社情報がユーザーに紐づくこと" do
+              sign_in user
+              expect {
+                post companies_path, params: { company: attributes_for(:company) }
+              }.to change { user.reload.company_id }.from(nil)
+            end
+
+            it "自社情報の作成・保存に成功すること" do
+              sign_in user
+              expect {
+                post companies_path, params: { company: attributes_for(:company) }
+              }.to change(Company, :count).by(1)
+            end
+
+            it "自社情報編集ページにリダイレクトすること" do
+              sign_in user
+              post companies_path, params: { company: attributes_for(:company) }
+              expect(response).to redirect_to(edit_company_path(user.reload.company))
+            end
+          end
+
+          context "無効なパラメータを送信した場合" do
+            it "ステータスコード422を返すこと" do
+              sign_in user
+              post companies_path, params: { company: attributes_for(:company, :invalid) }
+              expect(response).to have_http_status(:unprocessable_entity)
+            end
+
+            it "自社情報の作成・保存に失敗すること" do
+              sign_in user
+              expect {
+                post companies_path, params: { company: attributes_for(:company, :invalid) }
+              }.not_to change(Company, :count)
+            end
+          end
+        end
+
+        context "generalユーザーの場合" do
+          let(:user) { create(:user, :general, company: nil) }
+
+          it "招待待ちページにリダイレクトすること" do
+            sign_in user
+            post companies_path, params: { company: attributes_for(:company) }
+            expect(response).to redirect_to(invitation_required_path)
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/companies_spec.rb
+++ b/spec/requests/companies_spec.rb
@@ -2,324 +2,291 @@ require "rails_helper"
 
 RSpec.describe "Companies", type: :request do
   describe "GET /companies/:id" do
-    context "ログイン済みの場合" do
-      context "company登録済みの場合" do
-        context "adminユーザーの場合" do
-          let(:user) { create(:user, :admin, :with_company) }
+    context "adminユーザー（company登録済み）の場合" do
+      let(:user) { create(:user, :admin, :with_company) }
 
-          it "トップページにリダイレクトすること" do
-            sign_in user
-            get company_path(user.company)
-            expect(response).to redirect_to(root_path)
-          end
-        end
+      it "トップページにリダイレクトすること" do
+        sign_in user
+        get company_path(user.company)
+        expect(response).to redirect_to(root_path)
+      end
+    end
 
-        context "generalユーザーの場合" do
-          let(:user) { create(:user, :general, :with_company) }
+    context "generalユーザー（company登録済み）の場合" do
+      let(:user) { create(:user, :general, :with_company) }
 
-          it "HTTPステータス200を返すこと" do
-            sign_in user
-            get company_path(user.company)
-            expect(response).to have_http_status(:ok)
-          end
-
-          it "自社情報が取得できること" do
-            sign_in user
-            get company_path(user.company)
-            expect(response.body).to include(user.company.name)
-          end
-        end
+      it "HTTPステータス200を返すこと" do
+        sign_in user
+        get company_path(user.company)
+        expect(response).to have_http_status(:ok)
       end
 
-      context "company未登録の場合" do
-        let(:other_user) { create(:user, :admin, :with_company) }
+      it "自社情報が取得できること" do
+        sign_in user
+        get company_path(user.company)
+        expect(response.body).to include(user.company.name)
+      end
+    end
 
-        context "adminユーザーの場合" do
-          let(:user) { create(:user, :admin, company: nil) }
 
-          it "自社情報登録ページにリダイレクトすること" do
-            sign_in user
-            get company_path(other_user.company)
-            expect(response).to redirect_to(new_company_path)
-          end
-        end
+    context "adminユーザー（company未登録）の場合" do
+      let(:user) { create(:user, :admin, company: nil) }
+      let(:other_user) { create(:user, :admin, :with_company) }
 
-        context "generalユーザーの場合" do
-          let(:user) { create(:user, :general, company: nil) }
+      it "自社情報登録ページにリダイレクトすること" do
+        sign_in user
+        get company_path(other_user.company)
+        expect(response).to redirect_to(new_company_path)
+      end
+    end
 
-          it "招待待ちページにリダイレクトすること" do
-            sign_in user
-            get company_path(other_user.company)
-            expect(response).to redirect_to(invitation_required_path)
-          end
-        end
+    context "generalユーザー（company未登録）の場合" do
+      let(:user) { create(:user, :general, company: nil) }
+      let(:other_user) { create(:user, :admin, :with_company) }
+
+      it "招待待ちページにリダイレクトすること" do
+        sign_in user
+        get company_path(other_user.company)
+        expect(response).to redirect_to(invitation_required_path)
       end
     end
   end
 
   describe "GET /companies/new" do
-    context "ログイン済みの場合" do
-      context "company登録済みの場合" do
-        context "adminユーザーの場合" do
-          let(:user) { create(:user, :admin, :with_company) }
+    context "adminユーザー（company登録済み）の場合" do
+      let(:user) { create(:user, :admin, :with_company) }
 
-          it "トップページにリダイレクトすること" do
-            sign_in user
-            get new_company_path
-            expect(response).to redirect_to(root_path)
-          end
-        end
-
-        context "generalユーザーの場合" do
-          let(:user) { create(:user, :general, :with_company) }
-
-          it "トップページにリダイレクトすること" do
-            sign_in user
-            get new_company_path
-            expect(response).to redirect_to(root_path)
-          end
-        end
+      it "トップページにリダイレクトすること" do
+        sign_in user
+        get new_company_path
+        expect(response).to redirect_to(root_path)
       end
+    end
 
-      context "company未登録の場合" do
-        context "adminユーザーの場合" do
-          let(:user) { create(:user, :admin, company: nil) }
+    context "generalユーザー（company登録済み）の場合" do
+      let(:user) { create(:user, :general, :with_company) }
 
-          it "HTTPステータス200を返すこと" do
-            sign_in user
-            get new_company_path
-            expect(response).to have_http_status(:ok)
-          end
-        end
+      it "トップページにリダイレクトすること" do
+        sign_in user
+        get new_company_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
 
-        context "generalユーザーの場合" do
-          let(:user) { create(:user, :general, company: nil) }
+    context "adminユーザー（company未登録）の場合" do
+      let(:user) { create(:user, :admin, company: nil) }
 
-          it "招待待ちページにリダイレクトすること" do
-            sign_in user
-            get new_company_path
-            expect(response).to redirect_to(invitation_required_path)
-          end
-        end
+      it "HTTPステータス200を返すこと" do
+        sign_in user
+        get new_company_path
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "generalユーザー（company未登録）の場合" do
+      let(:user) { create(:user, :general, company: nil) }
+
+      it "招待待ちページにリダイレクトすること" do
+        sign_in user
+        get new_company_path
+        expect(response).to redirect_to(invitation_required_path)
       end
     end
   end
 
   describe "POST /companies" do
-    context "ログイン済みの場合" do
-      context "company登録済みの場合" do
-        context "adminユーザーの場合" do
-          let(:user) { create(:user, :admin, :with_company) }
+    context "adminユーザー（company登録済み）の場合" do
+      let(:user) { create(:user, :admin, :with_company) }
 
-          it "トップページにリダイレクトすること" do
-            sign_in user
-            post companies_path, params: { company: attributes_for(:company) }
-            expect(response).to redirect_to(root_path)
-          end
+      it "トップページにリダイレクトすること" do
+        sign_in user
+        post companies_path, params: { company: attributes_for(:company) }
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "generalユーザー（company登録済み）の場合" do
+      let(:user) { create(:user, :general, :with_company) }
+
+      it "トップページにリダイレクトすること" do
+        sign_in user
+        post companies_path, params: { company: attributes_for(:company) }
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "adminユーザー（company未登録）の場合" do
+      let(:user) { create(:user, :admin, company: nil) }
+
+      context "有効なパラメータを送信した場合" do
+        it "ステータスコード303を返すこと" do
+          sign_in user
+          post companies_path, params: { company: attributes_for(:company) }
+          expect(response).to have_http_status(:see_other)
         end
 
-        context "generalユーザーの場合" do
-          let(:user) { create(:user, :general, :with_company) }
-
-          it "トップページにリダイレクトすること" do
-            sign_in user
+        it "作成した自社情報がユーザーに紐づくこと" do
+          sign_in user
+          expect {
             post companies_path, params: { company: attributes_for(:company) }
-            expect(response).to redirect_to(root_path)
-          end
+          }.to change { user.reload.company_id }.from(nil)
+        end
+
+        it "自社情報の作成・保存に成功すること" do
+          sign_in user
+          expect {
+            post companies_path, params: { company: attributes_for(:company) }
+          }.to change(Company, :count).by(1)
+        end
+
+        it "自社情報編集ページにリダイレクトすること" do
+          sign_in user
+          post companies_path, params: { company: attributes_for(:company) }
+          expect(response).to redirect_to(edit_company_path(user.reload.company))
         end
       end
 
-      context "company未登録の場合" do
-        context "adminユーザーの場合" do
-          let(:user) { create(:user, :admin, company: nil) }
-
-          context "有効なパラメータを送信した場合" do
-            it "ステータスコード303を返すこと" do
-              sign_in user
-              post companies_path, params: { company: attributes_for(:company) }
-              expect(response).to have_http_status(:see_other)
-            end
-
-            it "作成した自社情報がユーザーに紐づくこと" do
-              sign_in user
-              expect {
-                post companies_path, params: { company: attributes_for(:company) }
-              }.to change { user.reload.company_id }.from(nil)
-            end
-
-            it "自社情報の作成・保存に成功すること" do
-              sign_in user
-              expect {
-                post companies_path, params: { company: attributes_for(:company) }
-              }.to change(Company, :count).by(1)
-            end
-
-            it "自社情報編集ページにリダイレクトすること" do
-              sign_in user
-              post companies_path, params: { company: attributes_for(:company) }
-              expect(response).to redirect_to(edit_company_path(user.reload.company))
-            end
-          end
-
-          context "無効なパラメータを送信した場合" do
-            it "ステータスコード422を返すこと" do
-              sign_in user
-              post companies_path, params: { company: attributes_for(:company, :invalid) }
-              expect(response).to have_http_status(:unprocessable_entity)
-            end
-
-            it "自社情報の作成・保存に失敗すること" do
-              sign_in user
-              expect {
-                post companies_path, params: { company: attributes_for(:company, :invalid) }
-              }.not_to change(Company, :count)
-            end
-          end
+      context "無効なパラメータを送信した場合" do
+        it "ステータスコード422を返すこと" do
+          sign_in user
+          post companies_path, params: { company: attributes_for(:company, :invalid) }
+          expect(response).to have_http_status(:unprocessable_entity)
         end
 
-        context "generalユーザーの場合" do
-          let(:user) { create(:user, :general, company: nil) }
-
-          it "招待待ちページにリダイレクトすること" do
-            sign_in user
-            post companies_path, params: { company: attributes_for(:company) }
-            expect(response).to redirect_to(invitation_required_path)
-          end
+        it "自社情報の作成・保存に失敗すること" do
+          sign_in user
+          expect {
+            post companies_path, params: { company: attributes_for(:company, :invalid) }
+          }.not_to change(Company, :count)
         end
+      end
+    end
+
+    context "generalユーザー（company未登録）の場合" do
+      let(:user) { create(:user, :general, company: nil) }
+
+      it "招待待ちページにリダイレクトすること" do
+        sign_in user
+        post companies_path, params: { company: attributes_for(:company) }
+        expect(response).to redirect_to(invitation_required_path)
       end
     end
   end
 
   describe "GET /companies/:id/edit" do
-    context "ログイン済みの場合" do
-      context "company登録済みの場合" do
-        context "adminユーザーの場合" do
-          let(:user) { create(:user, :admin, :with_company) }
+    context "adminユーザー（company登録済み）の場合" do
+      let(:user) { create(:user, :admin, :with_company) }
 
-          it "HTTPステータス200を返すこと" do
-            sign_in user
-            get edit_company_path(user.company)
-            expect(response).to have_http_status(:ok)
-          end
-        end
-
-        context "generalユーザーの場合" do
-          let(:user) { create(:user, :general, :with_company) }
-
-          it "トップページにリダイレクトすること" do
-            sign_in user
-            get edit_company_path(user.company)
-            expect(response).to redirect_to(root_path)
-          end
-        end
+      it "HTTPステータス200を返すこと" do
+        sign_in user
+        get edit_company_path(user.company)
+        expect(response).to have_http_status(:ok)
       end
+    end
 
-      context "company未登録の場合" do
-        let(:other_user) { create(:user, :admin, :with_company) }
+    context "generalユーザー（company登録済み）の場合" do
+      let(:user) { create(:user, :general, :with_company) }
 
-        context "adminユーザーの場合" do
-          let(:user) { create(:user, :admin, company: nil) }
+      it "トップページにリダイレクトすること" do
+        sign_in user
+        get edit_company_path(user.company)
+        expect(response).to redirect_to(root_path)
+      end
+    end
 
-          it "自社情報登録ページにリダイレクトすること" do
-            sign_in user
-            get edit_company_path(other_user.company)
-            expect(response).to redirect_to(new_company_path)
-          end
-        end
+    context "adminユーザー（company未登録）の場合" do
+      let(:user) { create(:user, :admin, company: nil) }
+      let(:other_user) { create(:user, :admin, :with_company) }
 
-        context "generalユーザーの場合" do
-          let(:user) { create(:user, :general, company: nil) }
+      it "自社情報登録ページにリダイレクトすること" do
+        sign_in user
+        get edit_company_path(other_user.company)
+        expect(response).to redirect_to(new_company_path)
+      end
+    end
 
-          it "招待待ちページにリダイレクトすること" do
-            sign_in user
-            get edit_company_path(other_user.company)
-            expect(response).to redirect_to(invitation_required_path)
-          end
-        end
+    context "generalユーザー（company未登録）の場合" do
+      let(:user) { create(:user, :general, company: nil) }
+      let(:other_user) { create(:user, :admin, :with_company) }
+
+      it "招待待ちページにリダイレクトすること" do
+        sign_in user
+        get edit_company_path(other_user.company)
+        expect(response).to redirect_to(invitation_required_path)
       end
     end
   end
 
   describe "PATCH /companies/:id" do
-    context "ログイン済みの場合" do
-      context "company登録済みの場合" do
-        context "adminユーザーの場合" do
-          let(:user) { create(:user, :admin, :with_company) }
+    context "adminユーザー（company登録済み）の場合" do
+      let(:user) { create(:user, :admin, :with_company) }
 
-          context "有効なパラメータを送信した場合" do
-            it "ステータスコード303を返すこと" do
-              sign_in user
-              patch company_path(user.company), params: { company: attributes_for(:company) }
-              expect(response).to have_http_status(:see_other)
-            end
-
-            it "自社情報の更新に成功すること" do
-              sign_in user
-              expect {
-                patch company_path(user.company), params: {
-                  company: attributes_for(:company, name: "新しい会社名")
-                }
-              }.to change { user.company.reload.name }.to("新しい会社名")
-            end
-
-            it "自社情報編集ページにリダイレクトすること" do
-              sign_in user
-              patch company_path(user.company), params: { company: attributes_for(:company) }
-              expect(response).to redirect_to(edit_company_path(user.company))
-            end
-          end
-
-          context "無効なパラメータを送信した場合" do
-            it "ステータスコード422を返すこと" do
-              sign_in user
-              patch company_path(user.company), params: { company: attributes_for(:company, :invalid) }
-              expect(response).to have_http_status(:unprocessable_entity)
-            end
-
-            it "自社情報の更新に失敗すること" do
-              sign_in user
-              expect {
-                patch company_path(user.company), params: {
-                  company: attributes_for(:company, :invalid)
-                }
-              }.not_to change { user.company.reload.name }
-            end
-          end
+      context "有効なパラメータを送信した場合" do
+        it "ステータスコード303を返すこと" do
+          sign_in user
+          patch company_path(user.company), params: { company: attributes_for(:company) }
+          expect(response).to have_http_status(:see_other)
         end
 
-        context "generalユーザーの場合" do
-          let(:user) { create(:user, :general, :with_company) }
+        it "自社情報の更新に成功すること" do
+          sign_in user
+          expect {
+            patch company_path(user.company), params: { company: attributes_for(:company, name: "新しい会社名") }
+          }.to change { user.company.reload.name }.to("新しい会社名")
+        end
 
-          it "トップページにリダイレクトすること" do
-            sign_in user
-            patch company_path(user.company), params: { company: attributes_for(:company) }
-            expect(response).to redirect_to(root_path)
-          end
+        it "自社情報編集ページにリダイレクトすること" do
+          sign_in user
+          patch company_path(user.company), params: { company: attributes_for(:company) }
+          expect(response).to redirect_to(edit_company_path(user.company))
         end
       end
 
-      context "company未登録の場合" do
-        let(:other_user) { create(:user, :admin, :with_company) }
-
-        context "adminユーザーの場合" do
-          let(:user) { create(:user, :admin, company: nil) }
-
-          it "自社情報登録ページにリダイレクトすること" do
-            sign_in user
-            patch company_path(other_user.company), params: { company: attributes_for(:company) }
-            expect(response).to redirect_to(new_company_path)
-          end
+      context "無効なパラメータを送信した場合" do
+        it "ステータスコード422を返すこと" do
+          sign_in user
+          patch company_path(user.company), params: { company: attributes_for(:company, :invalid) }
+          expect(response).to have_http_status(:unprocessable_entity)
         end
 
-        context "generalユーザーの場合" do
-          let(:user) { create(:user, :general, company: nil) }
-
-          it "招待待ちページにリダイレクトすること" do
-            sign_in user
-            patch company_path(other_user.company), params: { company: attributes_for(:company) }
-            expect(response).to redirect_to(invitation_required_path)
-          end
+        it "自社情報の更新に失敗すること" do
+          sign_in user
+          expect {
+            patch company_path(user.company), params: { company: attributes_for(:company, :invalid) }
+          }.not_to change { user.company.reload.name }
         end
+      end
+    end
+
+    context "generalユーザー（company登録済み）の場合" do
+      let(:user) { create(:user, :general, :with_company) }
+
+      it "トップページにリダイレクトすること" do
+        sign_in user
+        patch company_path(user.company), params: { company: attributes_for(:company) }
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "adminユーザー（company未登録）の場合" do
+      let(:user) { create(:user, :admin, company: nil) }
+      let(:other_user) { create(:user, :admin, :with_company) }
+
+      it "自社情報登録ページにリダイレクトすること" do
+        sign_in user
+        patch company_path(other_user.company), params: { company: attributes_for(:company) }
+        expect(response).to redirect_to(new_company_path)
+      end
+    end
+
+    context "generalユーザー（company未登録）の場合" do
+      let(:user) { create(:user, :general, company: nil) }
+      let(:other_user) { create(:user, :admin, :with_company) }
+
+      it "招待待ちページにリダイレクトすること" do
+        sign_in user
+        patch company_path(other_user.company), params: { company: attributes_for(:company) }
+        expect(response).to redirect_to(invitation_required_path)
       end
     end
   end

--- a/spec/requests/companies_spec.rb
+++ b/spec/requests/companies_spec.rb
@@ -56,4 +56,52 @@ RSpec.describe "Companies", type: :request do
       end
     end
   end
+
+  describe "GET /companies/new" do
+    context "ログイン済みの場合" do
+      context "company登録済みの場合" do
+        context "adminユーザーの場合" do
+          let(:user) { create(:user, :admin, :with_company) }
+
+          it "トップページにリダイレクトすること" do
+            sign_in user
+            get new_company_path
+            expect(response).to redirect_to(root_path)
+          end
+        end
+
+        context "generalユーザーの場合" do
+          let(:user) { create(:user, :general, :with_company) }
+
+          it "トップページにリダイレクトすること" do
+            sign_in user
+            get new_company_path
+            expect(response).to redirect_to(root_path)
+          end
+        end
+      end
+
+      context "company未登録の場合" do
+        context "adminユーザーの場合" do
+          let(:user) { create(:user, :admin, company: nil) }
+
+          it "HTTPステータス200を返すこと" do
+            sign_in user
+            get new_company_path
+            expect(response).to have_http_status(:ok)
+          end
+        end
+
+        context "generalユーザーの場合" do
+          let(:user) { create(:user, :general, company: nil) }
+
+          it "招待待ちページにリダイレクトすること" do
+            sign_in user
+            get new_company_path
+            expect(response).to redirect_to(invitation_required_path)
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 実施タスク
CompaniesControllerに関するRequest Spec作成 #51 

## 実施内容
- アプリケーションコードの修正
  - update アクション成功時のリダイレクト先を `company_url `から `edit_company_url(@company)` に修正
  - CompanyPolicy#show? において、general ユーザーのみが閲覧できるよう認可の条件を修正・追加
  - _navbar.html.erb で使用していた独自のヘルパーメソッド（show_navigation_link?, edit_navigation_link?）を削除し、Pundit 標準の show?, edit? を用いた条件分岐にリファクタリング
  - フラッシュメッセージの文末が句点（。）で終わるように修正
- テスト環境の整備
  - User モデルの FactoryBot に一般ユーザーを生成するための general trait を追加
- Request Spec の作成
  - issue #51 の「その他」に記載した表をもとに、CompaniesController#show, new, create, edit, updateについて、ステータスコードとリダイレクト先が期待通りか検証するRequest Specを作成した

## レビューして欲しいこと
- CompanyPolicy#show? の修正および、ナビゲーションバー（_navbar.html.erb）のリファクタリングは適切であるか
- `rspec spec/requests/companies_spec.rb` を実行し、全てのテストケースがパスすることを確認してください
- コードの可読性やテストの記述方法（context の切り方など）で改善点があればご指摘をお願いします

## 関連Issue
close #51 
