### PR TITLE
Users::InvitationsControllerの修正漏れ

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -2,6 +2,7 @@ class Users::InvitationsController < Devise::InvitationsController
   after_action :verify_authorized, only: %i[ new create ]
   before_action :require_admin!, only: %i[ new create ]
   before_action :reject_company_user!, only: %i[ create ]
+  before_action :reject_admin_user!, only: %i[ create ]
 
   skip_before_action :authenticate_user!, only: %i[ edit update ]
   skip_before_action :require_no_authentication, only: %i[ edit update ]


### PR DESCRIPTION
## 実施タスク
Users::InvitationsControllerの修正漏れ #57 

## 実施内容
 Users::InvitationsController#create に `before_action :reject_admin_user!` を追加しました

## レビューして欲しいこと
rspec spec/requests/users/invitations_spec.rb を実行し、全てのテストケースがパスすることを確認してください

## 関連Issue
close #57 
